### PR TITLE
Fix default workers in optimize function

### DIFF
--- a/biomass/core.py
+++ b/biomass/core.py
@@ -153,7 +153,7 @@ def optimize(
             (method='Powell' or 'DE') The maximum number of iterations
             over which the entire population is evolved.
 
-        * workers : int (default: -1 if `x_id` is `Iterable` else 1)
+        * workers : int (default: -1 if isinstance(x_id, `int`) else 1)
             (method='DE') The population is subdivided into workers sections and
             evaluated in parallel (uses multiprocessing.Pool). Supply -1 to use
             all available CPU cores. Set workers to 1 when searching multiple
@@ -185,7 +185,7 @@ def optimize(
     options.setdefault("local_search_method", "mutation")
     options.setdefault("n_children", 1000)
     options.setdefault("maxiter", 10)
-    options.setdefault("workers", -1 if not isinstance(x_id, int) else 1)
+    options.setdefault("workers", -1 if isinstance(x_id, int) else 1)
     options.setdefault("overwrite", False)
 
     _check_optional_arguments(x_id, options)
@@ -249,7 +249,7 @@ def optimize_continue(
             (method='Powell' or 'DE') The maximum number of iterations
             over which the entire population is evolved.
 
-        * workers : int (default: -1 if `x_id` is `Iterable` else 1)
+        * workers : int (default: -1 if isinstance(x_id, `int`) else 1)
             (method='DE') The population is subdivided into workers sections and
             evaluated in parallel (uses multiprocessing.Pool). Supply -1 to use
             all available CPU cores. Set workers to 1 when searching multiple
@@ -285,7 +285,7 @@ def optimize_continue(
     options.setdefault("local_search_method", "mutation")
     options.setdefault("n_children", 1000)
     options.setdefault("maxiter", 10)
-    options.setdefault("workers", -1 if not isinstance(x_id, int) else 1)
+    options.setdefault("workers", -1 if isinstance(x_id, int) else 1)
     options.setdefault("p0_bounds", [0.1, 10.0])
 
     _check_optional_arguments(x_id, options)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -108,6 +108,7 @@ Progress list: ``out/n/optimization.log``::
             "allowable_error": 0.5,
             "local_search_method": "DE",
             "maxiter": 50,
+            "workers": 1,
         }
     )
 

--- a/tests/test_mapk_cascade.py
+++ b/tests/test_mapk_cascade.py
@@ -83,7 +83,6 @@ def test_optimize():
             "popsize": 3,
             "max_generation": 9,
             "local_search_method": "DE",
-            "workers": 1,
         },
     )
     for paramset in range(1, 4):


### PR DESCRIPTION
Example:

```python
from biomass import Model, optimize
from biomass.models import Nakakuki_Cell_2010

model = Model(Nakakuki_Cell_2010.__package__).create()

optimize(
    model, x_id=range(1, 11), options={
        "local_search_method": "DE",
    }
)
```
> AssertionError: daemonic processes are not allowed to have children. Set options['workers'] to 1.

We should set workers to 1 when `isinstance(x_id, int) == False`.

Core function:

```python
options.setdefault("workers", -1 if isinstance(x_id, int) else 1)
```

Documentation:

Specify `options["workers"]` when using `"DE"` for local search method and searching multiple parameter sets simultaneously.