### PR TITLE
Drop support for Python 3.8 & 3.9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.12']
+        python-version: ['3.10', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -9,8 +9,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The BioMASS library is available at the [Python Package Index (PyPI)](https://py
 $ pip install biomass
 ```
 
-BioMASS supports Python 3.8 or newer.
+BioMASS supports Python 3.10 or newer.
 
 ## References
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,7 +1,7 @@
 Installation
 ============
 
-BioMASS supports Python 3.8 or newer.
+BioMASS supports Python 3.10 or newer.
 
 
 PyPI

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,18 +21,17 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering",
     "Topic :: Scientific/Engineering :: Bio-Informatics",
     "Topic :: Software Development",
     "Topic :: Software Development :: Libraries",
     "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dependencies = [
     "matplotlib>=3.0",
     "numba>=0.56",
@@ -77,7 +76,7 @@ version = {attr = "biomass.version.__version__"}
 
 [tool.black]
 line-length = 99
-target-version = ['py39']
+target-version = ['py311']
 exclude = '''
 /(
     \.eggs


### PR DESCRIPTION
- Close #283 
- Drop Python 3.9 support
- Add support for Python 3.13